### PR TITLE
Add post_id to required_fields

### DIFF
--- a/web/models/comment.ex
+++ b/web/models/comment.ex
@@ -9,7 +9,7 @@ defmodule BlogPhoenix.Comment do
     timestamps
   end
 
-  @required_fields ~w(name content)
+  @required_fields ~w(name content post_id)
   @optional_fields ~w()
 
   @doc """


### PR DESCRIPTION
The post_id needs to be set as a required or optional field so it can be assigned to the model in the changeset.
